### PR TITLE
Fixed for compatibility with jQuery 3.x version.

### DIFF
--- a/pgwbrowser.js
+++ b/pgwbrowser.js
@@ -254,7 +254,7 @@
             setViewportOrientation();
         });
 
-        $(window).resize(function(e) {
+        $(window).on('resize', function(e) {
             setViewportSize();
         });
 


### PR DESCRIPTION
jQuery 3.X 버전에서 권장하는 이벤트 바인딩 형식입니다.
```javascript
.on('event', function(){
     .......
})
```
['jQuery v3.0 reference'](https://jquery.com/upgrade-guide/3.0/)