### PR TITLE
Fixed for compatibility with jQuery 3.X version.

### DIFF
--- a/pgwbrowser.js
+++ b/pgwbrowser.js
@@ -254,7 +254,7 @@
             setViewportOrientation();
         });
 
-        $(window).resize(function(e) {
+        $(window).on('resize', function(e) {
             setViewportSize();
         });
 


### PR DESCRIPTION
This is the event bind format recommended by jQuery 3.X.
```javascript
$('selector').on('event', function(){
     ................
})
```
Fixed in the same format as above.

[jQuery v3.X reference](https://jquery.com/upgrade-guide/3.0/)